### PR TITLE
Updated port in server to use the PORT env variable when specified, else defaults to port 3000 (so that it works with heroku hosting)

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,8 +9,8 @@ const cookieSession = require('cookie-session');
 const keys = require('./config/keys');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
-
 const app = express();
+const port = process.env.PORT || 3000; // for heroku hosting
 
 
 app.use('/build', express.static(path.join(__dirname, 'build')));
@@ -144,8 +144,8 @@ pool.connect((err, result) => {
 
 
 
-	app.listen(3000, () => {
-		console.log('listening on port 3000...');
+	app.listen(port, () => {
+		console.log(`listening on port ${port}...`);
 	});
 
 })


### PR DESCRIPTION
Updated port in server to use the PORT env variable when specified, else defaults to port 3000 (so that it works with heroku hosting).

It's pretty much a one-line change.

It can be run with "heroku local web"... if you guys are interested in testing out the local Heroku env (how it'll be running on herokuapp.com)... otherwise disregard this and run it as you usually do.